### PR TITLE
Add constants

### DIFF
--- a/src/components/package-version.jsx
+++ b/src/components/package-version.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 
+import { APP_VERSION } from '../constant';
+
 const navStyles = {
   fontSize: '0.5em',
   letterSpacing: '0.2em',
@@ -10,7 +12,7 @@ class PackageVersion extends Component {
     super(props);
 
     this.state = {
-      version: process.env.npm_package_version,
+      version: APP_VERSION,
     };
   }
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,3 @@
+export const APP_VERSION = process.env.npm_package_version || 'x.x.x';
+export const ENVIRONMENT = process.env.NODE_ENV || 'development';
+export const DEBUG = process.env.NODE_ENV === 'development';

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -6,13 +6,14 @@ import thunkMiddleware from 'redux-thunk';
 import authMiddleware from './modules/auth/middleware';
 import rootReducer from './../redux/reducer';
 
+import { DEBUG } from '../constant';
 
 const middlewares = [
   thunkMiddleware,
   authMiddleware,
 ];
 
-if (process.env.NODE_ENV !== 'production') {
+if (DEBUG) {
   middlewares.push(createLogger());
 }
 

--- a/src/utils/auth-config.js
+++ b/src/utils/auth-config.js
@@ -1,3 +1,5 @@
+import { ENVIRONMENT } from '../constant';
+
 const AUTH_CONFIG = {
   test: {
     domain: 'signsfive.auth0.test',
@@ -16,4 +18,4 @@ const AUTH_CONFIG = {
   },
 };
 
-export default AUTH_CONFIG[process.env.NODE_ENV];
+export default AUTH_CONFIG[ENVIRONMENT];


### PR DESCRIPTION
We are already doing constants with node's `process.env` signsfive-api - see: https://github.com/deafchi/signsfive-api/blob/develop/src/config/constant.js 

We should do same in here too.